### PR TITLE
Removing non-date dirs from sorting

### DIFF
--- a/src/reports.js
+++ b/src/reports.js
@@ -13,7 +13,8 @@ const findReportPath = async (report, slug) => {
     throw e
   }
   const items = await fs.promises.readdir(parent)
-  const name = items.sort().reverse()[0]
+  const filtered_items = items.filter(folder => !isNaN(Date.parse(folder)))
+  const name = filtered_items.sort().reverse()[0]
   return name && `${parent}/${name}`
 }
 


### PR DESCRIPTION
This avoids situations when dirs not containing a report file are used instead of the appropriate ones.